### PR TITLE
Fix handling of bare `DATABRICKS_HOST` URLs

### DIFF
--- a/R/api_client.R
+++ b/R/api_client.R
@@ -91,6 +91,11 @@ DatabricksClient <- function(profile = NULL, host = NULL, token = NULL, config_f
     client_id = coalesce(Sys.getenv("DATABRICKS_CLIENT_ID"), from_cli$client_id),
     client_secret = coalesce(Sys.getenv("DATABRICKS_CLIENT_SECRET"), from_cli$client_secret))
 
+  # add the missing https:// prefix to bare, ODBC-style hosts
+  if (!is.null(cfg$host) && !startsWith(cfg$host, "http")) {
+    cfg$host <- paste0("https://", cfg$host)
+  }
+
   # debug_string iterates over currently resolved configuration and returns a
   # single string with all config key-value pairs that are effective in the
   # current state. Sensitive values are redated. Unlike Go, Python, or Java


### PR DESCRIPTION
Some platforms set `DATABRICKS_HOST` without the leading "https" for compatibility with existing ODBC code. Most other Databricks SDKs seem to detect this automatically and prefix the host as required, but until this commit this one did not.

(Note that this SDK is currently unusable inside Posit Workbench as a result of this limitation.)

Closes #22.