### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version changelog
 
+## 0.3.1
+
+* Added tokei.rs badge ([#27](https://github.com/databrickslabs/databricks-sdk-r/pull/27)).
+* Fix handling of bare DATABRICKS_HOST URLs. ([#25](https://github.com/databrickslabs/databricks-sdk-r/pull/25)).
+
+
 ## 0.3.0
 
 * Added github pages ([#19](https://github.com/databrickslabs/databricks-sdk-r/pull/19)).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: databricks
 Type: Package
 Title: Databricks SDK for R (Experimental)
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("Serge", "Smertin", email = "serge.smertin@databricks.com", role = c("aut", "cre")),
     person("Databricks", role = c("cph", "fnd"))

--- a/R/version.R
+++ b/R/version.R
@@ -1,1 +1,1 @@
-VERSION = "0.3.0"
+VERSION = "0.3.1"


### PR DESCRIPTION

* Added tokei.rs badge ([#27](https://github.com/databrickslabs/databricks-sdk-r/pull/27)).
* Fix handling of bare DATABRICKS_HOST URLs. ([#25](https://github.com/databrickslabs/databricks-sdk-r/pull/25)).


