### PR TITLE
Release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version changelog
 
+## 0.3.2
+
+* Regenerated from the latest OpenAPI spec ([#29](https://github.com/databrickslabs/databricks-sdk-r/pull/29)).
+
+
 ## 0.3.1
 
 * Added tokei.rs badge ([#27](https://github.com/databrickslabs/databricks-sdk-r/pull/27)).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: databricks
 Type: Package
 Title: Databricks SDK for R (Experimental)
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(
     person("Serge", "Smertin", email = "serge.smertin@databricks.com", role = c("aut", "cre")),
     person("Databricks", role = c("cph", "fnd"))

--- a/R/version.R
+++ b/R/version.R
@@ -1,1 +1,1 @@
-VERSION = "0.3.1"
+VERSION = "0.3.2"


### PR DESCRIPTION

* Regenerated from the latest OpenAPI spec ([#29](https://github.com/databrickslabs/databricks-sdk-r/pull/29)).


